### PR TITLE
Sync bridge: request_sync/send_sync from plain-def handlers, with the sync-vs-async rationale documented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.1.0 (unreleased)
 
+- Sync bridge: `PostOffice.request_sync()` / `send_sync()` let a plain `def` handler
+  (the synchronous ecosystem - `requests`, NumPy/ML inference, database drivers) call
+  sibling or remote functions - the call runs on the host event loop while only the
+  handler's worker thread blocks; the trace chain rides across unbroken. Calling the
+  bridge from async code, or outside a hosted function, is refused with a teaching
+  error. The sync-vs-async handler rationale is now documented (README and the
+  registry module).
 - Actuator endpoints `/info`, `/info/routes`, `/env`, `/health` and `/livenessprobe` -
   the engines' operational surface, for Kubernetes probes and one-dashboard monitoring
   of polyglot installations. Health check functions are normal registered functions

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Accenture.
+   Copyright 2018-2026 Accenture.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -69,8 +69,21 @@ now executes the Python function, with trace context carried end to end.
 
 A handler receives the same two-part input as an engine `TypedLambdaFunction` —
 `(headers: dict[str, str], body: Body)` — `Body` is any MsgPack value — and returns the reply body (or an `EventEnvelope` for full
-control of status and reply headers). `async def` and plain `def` are both supported;
-synchronous handlers run in a thread-pool executor so the event loop never blocks.
+control of status and reply headers). **Both `async def` and plain `def` handlers are
+first-class**, because Python has two library ecosystems and a polyglot function must be
+able to wrap either:
+
+- **plain `def`** — for the synchronous world: `requests` (one of the most popular HTTP
+  clients), NumPy/pandas and most ML inference stacks, database drivers. These handlers
+  run in a thread-pool executor, so a blocking call can never stall the event loop that
+  hosts every other function. This is the Python analog of the Java engine's virtual
+  threads: write sequential blocking-style code and the platform makes it safe.
+- **`async def`** — for asyncio-native I/O and for composing sibling functions with
+  `await po.request(...)`.
+
+The style is detected automatically (no flag to set), and trace context, `instances`,
+envelopes and telemetry behave identically in both. Rule of thumb: wrapping a blocking
+library → plain `def`; composing functions or async I/O → `async def`.
 
 - Raise `AppException(status, message)` for intentional errors — it becomes the portable
   error contract on the wire (envelope status + message), handled by the calling flow's
@@ -93,6 +106,11 @@ the engines' semantics for an in-app `po` call:
 - `instances` is faithful: each route has one FIFO mailbox consumed by that many worker
   tasks. RPC waits are bounded by `timeout_ms` (the standard 408 envelope on breach), and
   a queued call whose caller already timed out is skipped, never wastefully executed.
+- **Sync handlers compose too**: `po.request_sync(...)` / `po.send_sync(...)` run the
+  same call on the host loop while blocking only the handler's own worker thread — the
+  trace chain rides across the bridge unbroken. Calling the sync bridge from async code
+  is refused with a teaching error (`await po.request(...)` is the async way), and using
+  it outside a hosted function tells you to use `asyncio.run(po.request(...))` instead.
 - There is **no spill tier and no queue cap** by design: back-pressure belongs to the tier
   that owns recovery — the engines' flows and graphs. A leaf host fails fast by deadline
   instead of hoarding work.

--- a/examples/demo_app.py
+++ b/examples/demo_app.py
@@ -17,6 +17,7 @@ Then map a route from a Mercury engine application (event-over-http.yaml):
 from mercury_composable import (
     AppException,
     Body,
+    PostOffice,
     annotate_trace,
     get_logger,
     platform,
@@ -57,8 +58,6 @@ async def suffix_helper(_headers: dict[str, str], body: Body):
 @preload(route="hello.chain", instances=10)
 async def chain(_headers: dict[str, str], body: Body):
     """Local composition: a public function calls a private sibling through the bus."""
-    from mercury_composable import PostOffice
-
     reply = await PostOffice().request("demo.suffix.helper", body=body, timeout_ms=5000)
     return reply.body
 
@@ -68,8 +67,6 @@ def sync_chain(_headers: dict[str, str], body: Body):
     """Sync composition: a plain-def handler (the requests/NumPy world) calls a
     sibling through the sync bridge - blocking its own worker thread only,
     never the event loop."""
-    from mercury_composable import PostOffice
-
     reply = PostOffice().request_sync("demo.suffix.helper", body=body, timeout_ms=5000)
     return reply.body
 

--- a/examples/demo_app.py
+++ b/examples/demo_app.py
@@ -63,6 +63,17 @@ async def chain(_headers: dict[str, str], body: Body):
     return reply.body
 
 
+@preload(route="hello.sync.chain", instances=10)
+def sync_chain(_headers: dict[str, str], body: Body):
+    """Sync composition: a plain-def handler (the requests/NumPy world) calls a
+    sibling through the sync bridge - blocking its own worker thread only,
+    never the event loop."""
+    from mercury_composable import PostOffice
+
+    reply = PostOffice().request_sync("demo.suffix.helper", body=body, timeout_ms=5000)
+    return reply.body
+
+
 @preload(route="demo.health", instances=5, private=True)
 async def health_check(headers: dict[str, str], _body: Body):
     """Health check speaking the engines' interface contract (type=info / type=health).

--- a/src/mercury_composable/bus.py
+++ b/src/mercury_composable/bus.py
@@ -42,6 +42,17 @@ if TYPE_CHECKING:
 
 log = get_logger("mercury.bus")
 
+# The loop hosting the current sync handler - stamped by _execute before the
+# handler is dispatched to the executor thread (copy_context carries it), so
+# PostOffice's sync bridge can submit coroutines back to the right loop.
+_HOST_LOOP: contextvars.ContextVar[asyncio.AbstractEventLoop | None] = \
+    contextvars.ContextVar("mercury_host_loop", default=None)
+
+
+def get_host_loop() -> asyncio.AbstractEventLoop | None:
+    """The event loop hosting the current sync handler (None off-host)."""
+    return _HOST_LOOP.get()
+
 
 class DeliveryTimeout(Exception):
     """An RPC delivery missed its deadline; adapters shape the 408 for their protocol."""
@@ -149,9 +160,15 @@ class EventBus:
             if service.is_async:
                 result = await service.handler(delivery.headers, delivery.body)
             else:
-                # copy_context() carries the trace contextvar into the executor thread
-                context = contextvars.copy_context()
-                result = await asyncio.get_running_loop().run_in_executor(
+                # stamp the host loop (for the PostOffice sync bridge), then let
+                # copy_context() carry trace + loop into the executor thread
+                loop = asyncio.get_running_loop()
+                loop_token = _HOST_LOOP.set(loop)
+                try:
+                    context = contextvars.copy_context()
+                finally:
+                    _HOST_LOOP.reset(loop_token)
+                result = await loop.run_in_executor(
                     None, lambda: context.run(service.handler, delivery.headers,
                                               delivery.body))
             reply = result if isinstance(result, EventEnvelope) else EventEnvelope(body=result)

--- a/src/mercury_composable/client.py
+++ b/src/mercury_composable/client.py
@@ -177,7 +177,8 @@ class PostOffice:
         return await self._call(route, body, headers, timeout_ms, endpoint,
                                 True, from_route, cid)
 
-    def _run_sync(self, factory: Callable[[], Coroutine[Any, Any, EventEnvelope]],
+    @staticmethod
+    def _run_sync(factory: Callable[[], Coroutine[Any, Any, EventEnvelope]],
                   timeout_ms: int) -> EventEnvelope:
         """Run a PostOffice coroutine from a sync handler's thread on the host loop."""
         try:

--- a/src/mercury_composable/client.py
+++ b/src/mercury_composable/client.py
@@ -20,20 +20,31 @@ processing belongs in Event Script and Knowledge Graph on the engines.
 
 The decoded reply envelope is authoritative in both modes: an error rides
 back as a normal envelope with status >= 400 — inspect ``reply.get_status()``.
+
+**Sync bridge**: a plain ``def`` handler runs on an executor thread with no
+event loop of its own, so it cannot ``await``. :meth:`PostOffice.request_sync`
+and :meth:`PostOffice.send_sync` submit the same calls onto the host loop and
+block only the handler's worker thread — never the event loop. The caller's
+trace context rides across the bridge, so the trace chain is unbroken. Calling
+the sync bridge from async code is refused with a teaching error (``await
+request()`` is the async way).
 """
 
 from __future__ import annotations
 
+import asyncio
+import concurrent.futures
 import re
+from collections.abc import Callable, Coroutine
 from typing import Any
 
 import aiohttp
 
-from .bus import DeliveryTimeout
+from .bus import DeliveryTimeout, get_host_loop
 from .envelope import EventEnvelope
 from .exceptions import AppException
 from .registry import FunctionRegistry, default_registry
-from .trace import get_trace
+from .trace import _reset_trace, _set_trace, get_trace
 
 _W3C_TRACE_ID = re.compile(r"^[0-9a-f]{32}$")
 _W3C_SPAN_ID = re.compile(r"^[0-9a-f]{16}$")
@@ -165,3 +176,66 @@ class PostOffice:
         """Drop-n-forget: returns the peer's 202 delivery acknowledgement envelope."""
         return await self._call(route, body, headers, timeout_ms, endpoint,
                                 True, from_route, cid)
+
+    def _run_sync(self, factory: Callable[[], Coroutine[Any, Any, EventEnvelope]],
+                  timeout_ms: int) -> EventEnvelope:
+        """Run a PostOffice coroutine from a sync handler's thread on the host loop."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass  # no loop in this thread - the sync bridge is applicable
+        else:
+            raise RuntimeError(
+                "request_sync()/send_sync() must not be called on the event loop - "
+                "await request()/send() instead")
+        loop = get_host_loop()
+        if loop is None:
+            raise RuntimeError(
+                "No Mercury host event loop in context - the sync bridge works inside "
+                "a hosted sync function; elsewhere use asyncio.run(po.request(...))")
+        info = get_trace()  # carried into this thread by the bus dispatch
+
+        async def bridged() -> EventEnvelope:
+            if info is None:
+                return await factory()
+            # a submitted Task runs in its own context - re-establish the caller's
+            # trace there (the SAME TraceInfo object, so the chain is unbroken)
+            token = _set_trace(info)
+            try:
+                return await factory()
+            finally:
+                _reset_trace(token)
+
+        future = asyncio.run_coroutine_threadsafe(bridged(), loop)
+        try:
+            # inner deadlines already shape 408 envelopes; this outer margin only
+            # guards a wedged path so an executor thread can never hang forever
+            return future.result(timeout=max(100, timeout_ms) / 1000 + 10)
+        except concurrent.futures.TimeoutError:
+            future.cancel()
+            return EventEnvelope().set_status(408).set_body(f"Timeout for {timeout_ms} ms")
+
+    def request_sync(self, route: str, body: Any = None, *,
+                     headers: dict[str, str] | None = None,
+                     timeout_ms: int = 30000,
+                     endpoint: str | None = None,
+                     from_route: str | None = None,
+                     cid: str | None = None) -> EventEnvelope:
+        """RPC from a plain ``def`` handler: blocks this worker thread only,
+        never the event loop, while the call runs on the host loop."""
+        return self._run_sync(
+            lambda: self.request(route, body, headers=headers, timeout_ms=timeout_ms,
+                                 endpoint=endpoint, from_route=from_route, cid=cid),
+            timeout_ms)
+
+    def send_sync(self, route: str, body: Any = None, *,
+                  headers: dict[str, str] | None = None,
+                  timeout_ms: int = 30000,
+                  endpoint: str | None = None,
+                  from_route: str | None = None,
+                  cid: str | None = None) -> EventEnvelope:
+        """Drop-n-forget from a plain ``def`` handler (see :meth:`request_sync`)."""
+        return self._run_sync(
+            lambda: self.send(route, body, headers=headers, timeout_ms=timeout_ms,
+                              endpoint=endpoint, from_route=from_route, cid=cid),
+            timeout_ms)

--- a/src/mercury_composable/registry.py
+++ b/src/mercury_composable/registry.py
@@ -5,9 +5,16 @@ Mirrors the engines' PreLoad vocabulary: a function is registered under a
 route name with an instance count (its concurrency limit) and a private flag.
 Handlers take ``(headers: dict[str, str], body)`` — the same two-part input as a
 TypedLambdaFunction — and return the reply body (or an EventEnvelope for full
-control of status and reply headers). Both ``async def`` and plain ``def``
-handlers are supported; synchronous handlers run in the default executor so
-they never block the event loop.
+control of status and reply headers).
+
+Both ``async def`` and plain ``def`` handlers are first-class, because Python
+has two library ecosystems: plain ``def`` wraps the synchronous world
+(``requests``, NumPy/pandas and most ML inference stacks, database drivers)
+and runs in the default executor so a blocking call never stalls the event
+loop — the Python analog of the Java engine's virtual threads; ``async def``
+serves asyncio-native I/O and function composition. Detection is automatic
+(``inspect.iscoroutinefunction``); sync handlers compose siblings via
+``PostOffice.request_sync`` / ``send_sync`` (the sync bridge in client.py).
 """
 
 from __future__ import annotations

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -1,8 +1,10 @@
 """Primitive event bus pins: local RPC (public+private), FIFO, workers, deadlines."""
 
 import asyncio
+import threading
 from collections.abc import AsyncIterator
 
+import pytest
 import pytest_asyncio
 
 from mercury_composable import Body, EventEnvelope, FunctionRegistry, PostOffice, trace_context
@@ -153,4 +155,75 @@ async def test_local_send_returns_ack_envelope(registry: FunctionRegistry):
     assert isinstance(ack, EventEnvelope)
     assert ack.get_status() == 202
     assert ack.body["type"] == "async"
+    await asyncio.wait_for(seen.wait(), timeout=5)
+
+
+async def test_sync_handler_composes_via_request_sync(registry: FunctionRegistry):
+    async def helper(_headers: dict[str, str], _body: Body):
+        info = get_trace()
+        assert info is not None
+        return {"helper_trace": info.trace_id, "helper_cid": info.cid}
+
+    def entry(_headers: dict[str, str], body: Body):  # plain def - executor thread
+        po = PostOffice(registry=registry)
+        reply = po.request_sync("bus.sync.helper", body=body, timeout_ms=5000)
+        assert isinstance(reply.body, dict)
+        return {"entry": "sync", **reply.body}
+
+    registry.register("bus.sync.helper", helper, private=True)
+    registry.register("bus.sync.entry", entry)
+    po = PostOffice(registry=registry)
+    with trace_context("trace-sync-1", "TEST /sync", cid="cid-sync-1"):
+        reply = await po.request("bus.sync.entry", body={}, timeout_ms=5000)
+    assert reply.get_status() == 200
+    # the trace chain crosses the executor thread and the bridge unbroken
+    assert reply.body == {"entry": "sync", "helper_trace": "trace-sync-1",
+                          "helper_cid": "cid-sync-1"}
+
+
+async def test_request_sync_refused_on_the_event_loop(registry: FunctionRegistry):
+    po = PostOffice(registry=registry)
+    with pytest.raises(RuntimeError, match="must not be called on the event loop"):
+        po.request_sync("bus.any.where", body={})
+
+
+async def test_request_sync_off_host_teaches(registry: FunctionRegistry):
+    po = PostOffice(registry=registry)
+    caught: list[str] = []
+
+    def bare_thread() -> None:  # no host loop in this thread's context
+        try:
+            po.request_sync("bus.any.where", body={})
+        except RuntimeError as e:
+            caught.append(str(e))
+
+    thread = threading.Thread(target=bare_thread)
+    thread.start()
+    thread.join()
+    assert len(caught) == 1
+    assert caught[0].startswith("No Mercury host event loop in context")
+
+
+async def test_sync_bridge_shapes_envelope_errors_and_acks(registry: FunctionRegistry):
+    seen = asyncio.Event()
+
+    async def sink(_headers: dict[str, str], _body: Body):
+        seen.set()
+
+    def entry(_headers: dict[str, str], _body: Body):
+        po = PostOffice(registry=registry)
+        missing = po.request_sync("bus.no.where", body={}, timeout_ms=1000)
+        ack = po.send_sync("bus.sync.sink", body={"n": 1})
+        return {"missing_status": missing.get_status(), "missing_body": missing.body,
+                "ack_status": ack.get_status()}
+
+    registry.register("bus.sync.sink", sink, private=True)
+    registry.register("bus.sync.errors", entry)
+    po = PostOffice(registry=registry)
+    reply = await po.request("bus.sync.errors", body={}, timeout_ms=5000)
+    assert reply.get_status() == 200
+    # error/ack shaping is identical through the bridge (envelopes, not exceptions)
+    assert reply.body == {"missing_status": 404,
+                          "missing_body": "Route bus.no.where not found",
+                          "ack_status": 202}
     await asyncio.wait_for(seen.wait(), timeout=5)

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -165,10 +165,10 @@ async def test_sync_handler_composes_via_request_sync(registry: FunctionRegistry
         return {"helper_trace": info.trace_id, "helper_cid": info.cid}
 
     def entry(_headers: dict[str, str], body: Body):  # plain def - executor thread
-        po = PostOffice(registry=registry)
-        reply = po.request_sync("bus.sync.helper", body=body, timeout_ms=5000)
-        assert isinstance(reply.body, dict)
-        return {"entry": "sync", **reply.body}
+        entry_po = PostOffice(registry=registry)
+        inner = entry_po.request_sync("bus.sync.helper", body=body, timeout_ms=5000)
+        assert isinstance(inner.body, dict)
+        return {"entry": "sync", **inner.body}
 
     registry.register("bus.sync.helper", helper, private=True)
     registry.register("bus.sync.entry", entry)
@@ -204,16 +204,16 @@ async def test_request_sync_off_host_teaches(registry: FunctionRegistry):
     assert caught[0].startswith("No Mercury host event loop in context")
 
 
-async def test_sync_bridge_shapes_envelope_errors_and_acks(registry: FunctionRegistry):
+async def test_sync_bridge_shapes_envelope_errors_and_ack(registry: FunctionRegistry):
     seen = asyncio.Event()
 
     async def sink(_headers: dict[str, str], _body: Body):
         seen.set()
 
     def entry(_headers: dict[str, str], _body: Body):
-        po = PostOffice(registry=registry)
-        missing = po.request_sync("bus.no.where", body={}, timeout_ms=1000)
-        ack = po.send_sync("bus.sync.sink", body={"n": 1})
+        entry_po = PostOffice(registry=registry)
+        missing = entry_po.request_sync("bus.no.where", body={}, timeout_ms=1000)
+        ack = entry_po.send_sync("bus.sync.sink", body={"n": 1})
         return {"missing_status": missing.get_status(), "missing_body": missing.body,
                 "ack_status": ack.get_status()}
 


### PR DESCRIPTION
## What

1. **Sync bridge** — `PostOffice.request_sync()` / `send_sync()`: a plain `def` handler
   (which runs on an executor thread with no event loop of its own) can now call sibling
   or remote functions. The bus stamps the host loop into the handler's context at
   dispatch; the bridge submits the same coroutines onto that loop via
   `run_coroutine_threadsafe`, blocking only the handler's worker thread — never the
   event loop. The caller's trace context is re-established inside the submitted task
   (contextvars do not cross `run_coroutine_threadsafe` on their own), so the trace
   chain is unbroken end to end. Misuse teaches: calling the bridge on the event loop →
   "await request()/send() instead"; calling it outside a hosted function → points at
   `asyncio.run(po.request(...))`. Errors stay envelope-shaped (404/408/202), identical
   to the async path.
2. **The sync-vs-async handler rationale is now documented** (README function contract +
   the registry module docstring): plain `def` handlers are first-class because Python's
   synchronous ecosystem — `requests`, NumPy/pandas and most ML inference stacks,
   database drivers — must be wrappable without stalling the event loop that hosts every
   other function; the executor dispatch is the Python analog of the Java engine's
   virtual threads. `async def` serves asyncio-native I/O and composition. Detection
   stays automatic; a rule of thumb closes the section.
3. Demo: `hello.sync.chain` (plain `def` → `request_sync` → private sibling);
   `PostOffice` hoisted to the demo's module-level import.

## Why

The design review ratified supporting both handler styles, but sync handlers had a
composition gap: `PostOffice.request()` is a coroutine and an executor thread cannot
await it — so the synchronous half of the ecosystem could wrap libraries yet not call
sibling functions. The bridge closes that gap with the same envelope contract, keeping
the two styles fully symmetric for developers.

## Verification

- 54/54 pytest — 4 new pins: sync entry → `request_sync` → private helper with the full
  trace/cid chain; refused-on-event-loop teaching error; off-host teaching error;
  404/202 envelope shaping + `send_sync` delivery. ruff clean, basedpyright 0.
- Live wire proof: `hello.sync.chain` driven over `/api/event` →
  `{'text': 'polyglot!', 'language': 'python'}`; re-verified after each follow-up commit.
- Follow-ups from the IDE review folded: `_run_sync` static, demo import hoist,
  unshadowed test locals.

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)