### PR TITLE
Engine-parity host polish: index page, pretty JSON, engine error shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.1.0 (unreleased)
 
+- Host polish for engine parity: `GET /` serves the engines' minimal index page linking
+  the actuator endpoints (embedded - no static file service by design); actuator JSON
+  responses are pretty-printed (the engines' default-serializer presentation); unknown
+  paths and non-GET methods answer the engines' error shape
+  `{"status": 404, "message": "Resource not found", "type": "error"}`.
 - Sync bridge: `PostOffice.request_sync()` / `send_sync()` let a plain `def` handler
   (the synchronous ecosystem - `requests`, NumPy/ML inference, database drivers) call
   sibling or remote functions - the call runs on the host event loop while only the

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Kubernetes probes and dashboards treat a Python app exactly like a Java or Rust 
 
 | Endpoint | Purpose |
 |----------|---------|
+| `GET /` | minimal index page linking the endpoints below |
 | `GET /info` | app identity, runtime, origin id, start time, uptime |
 | `GET /info/routes` | registered routes split by visibility, with instance counts |
 | `GET /env` | selected environment variables and configuration parameters |
@@ -174,6 +175,10 @@ async def health(headers: dict[str, str], _body: Body) -> Body:
         return {"service": "demo.service", "href": "http://127.0.0.1"}
     return "demo.service is running fine"   # a non-200 reply marks it down
 ```
+
+JSON responses are pretty-printed — the engines' default-serializer presentation — and
+unknown paths answer the engines' error shape
+(`{"status": 404, "message": "Resource not found", "type": "error"}`).
 
 Kubernetes wiring: point `livenessProbe` at `/livenessprobe` and `readinessProbe` at
 `/health`.

--- a/src/mercury_composable/actuator.py
+++ b/src/mercury_composable/actuator.py
@@ -39,6 +39,7 @@ functions, so the ``type=info`` lookup costs nothing).
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import platform as runtime_platform
 import re
@@ -61,6 +62,38 @@ log = get_logger("mercury.actuator")
 INFO_TIMEOUT_MS = 3000  # engine value for the advisory type=info lookup
 HEALTH_TIMEOUT_MS = 10000  # engine value for the type=health probe
 UNHEALTHY = "Unhealthy. Please check '/health' endpoint."
+
+# The engines' minimal landing page (platform-core public/index.html style);
+# the wrappers embed it - no static file service by design.
+INDEX_HTML = """<!DOCTYPE html>
+<html>
+<body>
+
+<h2>Welcome</h2>
+
+<p><a href="/info">INFO endpoint</a></p>
+<p><a href="/info/routes">Service list</a></p>
+<p><a href="/env">Environment endpoint</a></p>
+<p><a href="/health">Health endpoint</a></p>
+<p><a href="/livenessprobe">Liveness probe</a></p>
+
+</body>
+</html>"""
+
+
+def _pretty(payload: Any) -> str:
+    """The engines' default serializer presentation: pretty-printed JSON."""
+    return json.dumps(payload, indent=2, ensure_ascii=False)
+
+
+def _json_response(payload: dict[str, Any], status: int = 200) -> web.Response:
+    return web.json_response(payload, status=status, dumps=_pretty)
+
+
+def _error_response(status: int, message: str) -> web.Response:
+    """The engines' host-level error shape (SimpleHttpUtility signature)."""
+    return _json_response({"status": status, "message": message, "type": "error"},
+                          status=status)
 
 _SPLIT = re.compile(r"[,\s]+")
 
@@ -138,9 +171,14 @@ class Actuator:
                 "description": self.description}
 
     async def handle(self, request: web.Request) -> web.Response:
-        """The single GET dispatcher (aiohttp handlers must be coroutines):
-        /health awaits its dependency probes; the rest render synchronously."""
+        """The single dispatcher (aiohttp handlers must be coroutines):
+        /health awaits its dependency probes; the rest render synchronously.
+        Unknown paths and non-GET methods answer the engines' error shape."""
+        if request.method != "GET":
+            return _error_response(404, "Resource not found")
         match request.path:
+            case "/":
+                return web.Response(text=INDEX_HTML, content_type="text/html")
             case "/info":
                 return self._info()
             case "/info/routes":
@@ -151,12 +189,12 @@ class Actuator:
                 return await self._health()
             case "/livenessprobe":
                 return self._liveness_probe()
-            case _:  # the router only maps the five paths above here
-                return web.Response(status=404, text="Not found")
+            case _:
+                return _error_response(404, "Resource not found")
 
     def _info(self) -> web.Response:
         now = datetime.now(timezone.utc)
-        return web.json_response({
+        return _json_response({
             "app": self._app_block(),
             "runtime": {
                 "language": "python",
@@ -174,7 +212,7 @@ class Actuator:
         for route, service in sorted(self.registry.routes().items()):
             target = private if service.private else public
             target[route] = service.instances
-        return web.json_response({
+        return _json_response({
             "app": self._app_block(),
             "routing": {"public": public, "private": private},
         })
@@ -185,7 +223,7 @@ class Actuator:
                        for name in _as_list(config.get("show.env.variables"))}
         properties = {name: config.get_property(name) or ""
                       for name in _as_list(config.get("show.application.properties"))}
-        return web.json_response({
+        return _json_response({
             "app": self._app_block(),
             "env": {"environment": environment, "properties": properties},
         })
@@ -204,7 +242,7 @@ class Actuator:
         result["status"] = "UP" if up else "DOWN"
         result["origin"] = app_origin()
         result["name"] = self.app_name
-        return web.json_response(result, status=200 if up else 400)
+        return _json_response(result, status=200 if up else 400)
 
     def _liveness_probe(self) -> web.Response:
         if self.healthy:

--- a/src/mercury_composable/server.py
+++ b/src/mercury_composable/server.py
@@ -103,9 +103,13 @@ class EventApiServer:
     def create_app(self) -> web.Application:
         app = web.Application(client_max_size=16 * 1024 * 1024)
         app.router.add_post("/api/event", self.handle_event)
-        # the engines' actuator endpoints (see actuator.py)
-        for path in ("/info", "/info/routes", "/env", "/health", "/livenessprobe"):
+        # the engines' landing page + actuator endpoints (see actuator.py)
+        for path in ("/", "/info", "/info/routes", "/env", "/health", "/livenessprobe"):
             app.router.add_get(path, self.actuator.handle)
+        # any other path or method answers the engines' error shape, not
+        # aiohttp's default text page (exact routes above win - they are
+        # registered first)
+        app.router.add_route("*", "/{unknown:.*}", self.actuator.handle)
         return app
 
 

--- a/tests/test_actuator.py
+++ b/tests/test_actuator.py
@@ -196,3 +196,39 @@ def test_origin_is_stable_and_engine_shaped():
     minted = app_origin()
     assert minted == app_origin()  # minted once per process
     assert re.fullmatch(ORIGIN_SHAPE, minted)
+
+async def test_index_page_lists_actuator_endpoints():
+    async with (
+        actuator_server(FunctionRegistry()) as url,
+        aiohttp.ClientSession() as session,
+        session.get(f"{url}/") as response,
+    ):
+        assert response.status == 200
+        assert response.content_type == "text/html"
+        page = await response.text()
+    for link in ("/info", "/info/routes", "/env", "/health", "/livenessprobe"):
+        assert f'href="{link}"' in page
+
+
+async def test_unknown_path_answers_engine_error_shape():
+    async with actuator_server(FunctionRegistry()) as url:
+        status, body = await get_json(f"{url}/no/such/page")
+        # non-GET on a known path is equally not a resource (engine semantics)
+        async with aiohttp.ClientSession() as session, session.post(f"{url}/info") as response:
+            post_status = response.status
+            post_body = await response.json()
+    assert status == 404
+    assert body == {"status": 404, "message": "Resource not found", "type": "error"}
+    assert post_status == 404
+    assert post_body == {"status": 404, "message": "Resource not found", "type": "error"}
+
+
+async def test_json_responses_are_pretty_printed():
+    # the engines' default serializer presentation (SimpleMapper pretty Gson)
+    async with (
+        actuator_server(FunctionRegistry()) as url,
+        aiohttp.ClientSession() as session,
+        session.get(f"{url}/info") as response,
+    ):
+        text = await response.text()
+    assert text.startswith('{\n  "app": {\n')


### PR DESCRIPTION
## What

Three engine-parity refinements to the HTTP host, signatures extracted from the Java
engine first:

1. **`GET /` index page** — the engines' minimal Welcome page (platform-core
   `public/index.html` style) embedded as a constant, linking `/info`, `/info/routes`,
   `/env`, `/health` and `/livenessprobe`. Deliberately no static file service.
2. **Pretty-printed JSON** — actuator responses now use the engines' default-serializer
   presentation (Java `SimpleMapper` = pretty Gson; the Rust port matches): 2-space
   indented JSON.
3. **Host error shape** — unknown paths and non-GET methods on known paths answer the
   engines' `SimpleHttpUtility` signature: `{"status": 404, "message":
   "Resource not found", "type": "error"}` (Java key insertion order), pretty-printed
   with `application/json`. aiohttp's default text error page is no longer reachable
   (catch-all route behind the exact routes).

Content types confirmed live: `application/json; charset=utf-8` on all JSON endpoints
and errors, `text/plain` only on `/livenessprobe` (engine parity), `text/html` on `/`.
Envelope transport errors on `/api/event` are untouched (octet-stream envelopes).

## Why

Operations teams should not be able to tell a Python function host from an engine by
its HTTP presentation: the landing page, the JSON rendering, and the error signature
are part of the one-aggregation surface the polyglot initiative promises.

## Verification

57/57 pytest (new pins: index links, error shape for GET-unknown and POST-on-known,
pretty rendering), ruff clean, basedpyright 0. Live demo drive verified all three
shapes plus the content-type map; byte-symmetric with the node twin.

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)