### PR TITLE
agent-memory 4.39.1 — same-thread merge claim precision (docs-only)

### DIFF
--- a/.agent/schema.md
+++ b/.agent/schema.md
@@ -105,7 +105,8 @@ conventions:
   (`.agent/version.md` is the canonical version; `status`'s token is just a human cue.)
 - **Same-thread edits need a human.** Only a genuine semantic clash — both sides editing the
   *same* Open Thread file, or a `[ ]`→`[x]` race — warrants judgment; everything else is
-  mechanical. Thread files make that clash visible as a per-file conflict.
+  mechanical. Overlapping same-thread edits surface as a per-file conflict; separated edits
+  merge cleanly keeping both sides — run the contradiction check on the merged thread.
 - A left-behind conflict marker (`<<<<<<<`, `=======`, `>>>>>>>`) corrupts memory; `memory-lint`
   flags it as an ERROR.
 
@@ -153,9 +154,13 @@ and let the review archive it flagged "superseded." See `DECAY.md` §9.
 **One Open Thread per file** (v4.39.0). `<id>` is the thread's kebab fact id — the
 filename is the identity and **never changes** for the thread's lifetime; updates edit the
 file in place. This is what makes concurrent thread work merge-free: parallel branches
-touching *different* threads touch different files (no conflict possible), and both sides
-editing the *same* thread conflict per-file — a genuine Tier 2 semantic clash correctly
-reaching a human (`MERGE.md`).
+touching *different* threads touch different files (no conflict possible). Within the
+*same* thread file, ordinary git merge semantics apply (v4.39.1 precision): edits to
+adjacent/overlapping lines conflict — a genuine Tier 2 semantic clash correctly reaching
+a human (`MERGE.md`) — while edits separated by unchanged lines merge cleanly with
+**both sides kept** (nothing is lost; whether the two statements are *consistent* is the
+write-time contradiction check's job, `DECAY.md` §10 — exactly as it was when threads
+lived in continuity).
 
 File content is **exactly the thread's bullet block**, nothing else — the same shape that
 previously sat under continuity's `## Open Threads`:

--- a/.agent/version.md
+++ b/.agent/version.md
@@ -4,7 +4,7 @@
 > Mode B can detect drift and upgrade in place (see the tool's `UPGRADE.md`).
 > `version` gates the upgrade ladder — don't hand-edit it unless you mean to.
 
-- **version:**       4.39.0
+- **version:**       4.39.1
 - **enabled_with:**  4.38.0
 - **last_upgraded:** 2026-09-01
 - **mode:**          A

--- a/MERGE.md
+++ b/MERGE.md
@@ -45,6 +45,12 @@ Look at what actually diverged between the two sides:
   thread `[ ]`→`[x]` while the other edited it; or a fact was superseded on one side and
   edited on the other. The rare case — and the **only** one needing judgment. A thread-file
   conflict is *always* this class — the layout has already eliminated the mechanical cases.
+  (Precision, v4.39.1: git raises the conflict when same-thread edits touch
+  adjacent/overlapping lines. Edits separated by unchanged lines merge cleanly with **both
+  sides kept** — nothing is lost, but the merged thread may now hold two inconsistent
+  statements: give it the write-time contradiction check, `DECAY.md` §10. Same behavior as
+  when threads lived in continuity — the layout changed where conflicts land, not git's
+  hunk semantics.)
 
 ## (2) Resolve by tier
 

--- a/memory/sessions/2026-09-01-204728.md
+++ b/memory/sessions/2026-09-01-204728.md
@@ -1,0 +1,11 @@
+# Session (2026-09-01T20:47:28.000Z)
+
+**Agent:** Claude Code
+
+Lightweight: Mode B upgrade 4.39.0 → 4.39.1 (docs-only PATCH — MERGE.md + .agent/schema.md
+re-copied: the same-thread merge claim now states git's measured hunk boundary; no script,
+protocol, or shape change). memory-lint unchanged.
+
+## Memory References
+
+(none)


### PR DESCRIPTION
## What

agent-memory Mode B upgrade **4.39.0 → 4.39.1** (docs-only PATCH): `MERGE.md` and `.agent/schema.md` re-copied. The same-thread merge claim now states git's measured hunk boundary — adjacent/overlapping edits conflict (the Tier 2 human gate); edits separated by unchanged lines merge cleanly with both sides kept, and the merged thread gets the write-time contradiction check. No script, protocol, or memory-file shape change; `memory-lint` output unchanged.

## Why

An independent CoPilot assessment of v4.39.0 flagged the original claim as overstating git's guarantee; upstream verified it by live merge rehearsal and shipped the precision as v4.39.1. Honest docs beat optimistic ones. Upstream release: https://github.com/acn-ericlaw/agent-memory/releases/tag/v4.39.1

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
