### PR TITLE
Release v4.12.1 - first PyPI publication metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## Unreleased
+## Version 4.12.1, 9/1/2026
+
+The first PyPI release: `pip install mercury-composable`. The v4.12.0 lock-step line
+plus the AI-node demo functions below.
 
 ### Added
 
@@ -18,6 +21,9 @@
   progressively out its own HTTP edge as SSE. Terminal metadata carries model,
   stop_reason, usage and the trace/business correlation ids; provider errors fail the
   stream in-band. Live-proven end to end with real Gemini tokens (2026-08-31).
+- PyPI publication metadata: SPDX license expression (PEP 639), trove classifiers,
+  keywords, project URLs, and a constrained sdist (package sources, tests, examples
+  and top-level docs only - repo-internal layers never ship).
 
 ## 4.12.0 (2026-08-30)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mercury-composable"
-version = "4.12.0"
+version = "4.12.1"
 description = "Lightweight Event-over-HTTP function host and client for Mercury Composable"
 readme = "README.md"
-license = { file = "LICENSE.txt" }
+license = "Apache-2.0"
+license-files = ["LICENSE.txt"]
 authors = [{ name = "Accenture Technology" }]
 requires-python = ">=3.10"
 dependencies = [
@@ -15,16 +16,26 @@ dependencies = [
     "msgpack>=1.0,<2",
     "PyYAML>=6.0,<7",
 ]
+keywords = ["event-driven", "composable", "microservices", "event-over-http", "mercury"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: Apache Software License",
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: AsyncIO",
+    "Topic :: Software Development :: Libraries",
+    "Operating System :: OS Independent",
 ]
 
 [project.urls]
 Homepage = "https://github.com/Accenture/mercury-python"
-Documentation = "https://accenture.github.io/mercury-composable"
+Documentation = "https://accenture.github.io/mercury-python"
+Repository = "https://github.com/Accenture/mercury-python"
+Changelog = "https://github.com/Accenture/mercury-python/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 # the llm.chat demo function (examples/demo_app.py) - the package itself stays SDK-free
@@ -36,6 +47,18 @@ mercury-serve = "mercury_composable.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mercury_composable"]
+
+[tool.hatch.build.targets.sdist]
+# the sdist ships the package plus its teaching surfaces - never the repo's
+# agent-memory layer, skills, or CI plumbing
+only-include = [
+    "src/mercury_composable",
+    "tests",
+    "examples",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE.txt",
+]
 
 [tool.ruff]
 line-length = 100

--- a/src/mercury_composable/version.py
+++ b/src/mercury_composable/version.py
@@ -1,3 +1,3 @@
 """Package version - the single Python-side source (pyproject.toml mirrors it)."""
 
-__version__ = "4.12.0"
+__version__ = "4.12.1"


### PR DESCRIPTION
## What

The v4.12.1 release: PyPI publication metadata for `mercury-composable` (name verified
free on PyPI), riding the lock-step line with the engines.

- SPDX license expression + `license-files` (PEP 639); trove classifiers (Beta,
  Python 3.10-3.14, AsyncIO); keywords; project URLs corrected and extended -
  Documentation now points at this repo's own site (it pointed at the engine's).
- **Constrained sdist**: ships only the package sources, tests, examples and top-level
  docs - the repo-internal layers (agent memory, skills, CI plumbing) never ride the
  artifact. The wheel was already constrained to `src/mercury_composable`.
- Version 4.12.1 (`pyproject.toml` + `version.py`); CHANGELOG flipped - the 4.12.1
  section carries the llm.chat / llm.stream AI nodes shipped since v4.12.0.

## Why

Public package publication green-lit (P5 of the polyglot initiative); registry
artifacts should correspond to a tag, so the wrappers release v4.12.1 in lock-step
with the engines rather than publishing artifacts that do not match v4.12.0.

## Verification

97 tests + ruff green; `python -m build` + `twine check` PASSED on both artifacts;
sdist contents inspected (exactly the intended set); fresh-venv wheel install smoke
test on Python 3.14 (`import` at 4.12.1 + `mercury-serve --help`), with the system
Python 3.9 correctly rejected by `requires-python`.

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)