### PR TITLE
docs: the Mercury Family — membership line, Orientation page, two-column home

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,16 @@ summary: Externalized functions for Mercury Composable - write decoupled functio
   and let the Java/Rust engines orchestrate them from Event Script flows and knowledge graphs.
 audience: [developer, architect, ai-agent]
 keywords: [polyglot, python, event over http, composable, minigraph, externalized functions]
+hide:
+  - navigation
 ---
 
 # Externalized functions for Mercury Composable
 
 *Write the function in Python. Let the engine orchestrate it.*
+
+Part of the **[Mercury family](mercury-family.md)** — Accenture's open-source foundations
+for human–AI collaboration.
 
 > **At a glance**
 >

--- a/docs/mercury-family.md
+++ b/docs/mercury-family.md
@@ -1,0 +1,46 @@
+# The Mercury Family
+
+**Advanced software foundations for human–AI collaboration** — Accenture open source,
+Apache-2.0.
+
+Mercury is a family of open-source foundations for building software *with* AI, not merely
+faster: composable engines whose applications are assembled from self-contained functions and
+YAML-configured event flows — a shape that human developers and AI agents read equally well —
+plus a shared memory layer that keeps every human and every AI agent on a project oriented on
+the same intent and state.
+
+## Members
+
+| Member | Role | Repository | Documentation |
+| --- | --- | --- | --- |
+| **agent-memory** | Vendor-neutral shared AI memory + cognitive loop — no-code, markdown-only. Gives any repository one committed `memory/` that every AI agent and every contributor shares, with deterministic decay, supersession and a human-gated intent trace. Joined the family September 10, 2026. | [Accenture/mercury-go](https://github.com/Accenture/mercury-go) | [accenture.github.io/mercury-go](https://accenture.github.io/mercury-go/) |
+| **mercury-composable** | The Java engine — composable, event-driven applications in three layers: Platform Core, Event Script, Active Knowledge Graph. | [Accenture/mercury-composable](https://github.com/Accenture/mercury-composable) | [accenture.github.io/mercury-composable](https://accenture.github.io/mercury-composable/) |
+| **mercury** | The Rust engine — a twin implementation of mercury-composable: same three layers, same flow YAML (flow files port unchanged). | [Accenture/mercury](https://github.com/Accenture/mercury) | [accenture.github.io/mercury](https://accenture.github.io/mercury/) |
+| **mercury-python** | Python language pack — write composable functions in Python and call them from flows and knowledge graphs. | [Accenture/mercury-python](https://github.com/Accenture/mercury-python) | [accenture.github.io/mercury-python](https://accenture.github.io/mercury-python/) |
+| **mercury-nodejs** | Node.js language pack — write composable functions in Node.js and call them from flows and knowledge graphs. | [Accenture/mercury-nodejs](https://github.com/Accenture/mercury-nodejs) | [accenture.github.io/mercury-nodejs](https://accenture.github.io/mercury-nodejs/) |
+
+## How the pieces fit
+
+- The **engines** (mercury-composable, mercury) run the application: functions addressed by
+  route name exchange immutable events, YAML flows sequence them, and a knowledge graph
+  provides the semantic layer.
+- The **language packs** (mercury-python, mercury-nodejs) extend the engines so functions can
+  be written in Python or Node.js and called from the same flows and graphs.
+- **agent-memory** carries the *project's* memory — Vision, Blueprint, continuity, session
+  records, architecture decisions — so the humans and AI agents building on the engines
+  orient on purpose and state, not only on API shape. Every Mercury repository is itself
+  AI-enabled with agent-memory: the family uses its own memory layer.
+
+## Using the brand
+
+- **Short form:** *the Mercury family — advanced software foundations for human–AI collaboration.*
+- **Member sentence** (for a member repository's README or site footer):
+
+> Part of the **Mercury family** — Accenture's open-source foundations for human–AI
+> collaboration: [agent-memory](https://accenture.github.io/mercury-go/) ·
+> [mercury-composable](https://accenture.github.io/mercury-composable/) ·
+> [mercury](https://accenture.github.io/mercury/) ·
+> [mercury-python](https://accenture.github.io/mercury-python/) ·
+> [mercury-nodejs](https://accenture.github.io/mercury-nodejs/).
+
+All members are published by Accenture under the Apache License 2.0.

--- a/memory/sessions/2026-09-10-220636.md
+++ b/memory/sessions/2026-09-10-220636.md
@@ -1,0 +1,30 @@
+# Session (2026-09-10T22:06:36.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Docs: the Mercury Family lands on the site** (Eric's request, following
+agent-memory's promotion into the family at github.com/Accenture/mercury-go);
+same-day treatment across all four Mercury repos — the engines carry a home
+hero button, the language packs carry a membership line:
+
+- `docs/mercury-family.md` — a byte-identical copy of the canonical family
+  page from mercury-go (members table, how the pieces fit, brand usage).
+- The home page states membership right under the tagline — "Part of the
+  **Mercury family**" — hyperlinking the family page. The relative link is
+  safe here: no AI-contract snapshot packages this home page (the engine
+  repos hit that constraint and use absolute site URLs instead).
+- Nav: the page sits UNDER the Orientation tab (Eric's standing constraint
+  from the engine sites: top tab bars have reached maximum rendered width —
+  never a new top-level tab).
+- The home page went two-column (`hide: navigation` front matter), matching
+  the agent-memory and engine homes.
+
+Verified: `mkdocs build --strict` green (the CI gate) and live `mkdocs
+serve` screenshots — two-column home, membership line, family page under
+Orientation in the left nav.
+
+## Memory References
+
+(none)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
 
   - Orientation:
     - Getting Started: guides/getting-started.md
+    - The Mercury Family: mercury-family.md
 
   - Foundations:
     - Rationale — Externalized Functions: guides/rationale.md


### PR DESCRIPTION
## What

The Mercury Family arrives on the documentation site, following agent-memory's promotion into the family (github.com/Accenture/mercury-go):

- New page `docs/mercury-family.md` — a byte-identical copy of the canonical family page from mercury-go: the five members, how the pieces fit, and brand usage.
- The home page states membership right under the tagline — "Part of the **Mercury family**" — hyperlinking the family page.
- Nav: the page sits **under the Orientation tab** — consistent with the engine sites, no new top-level tab.
- The home page becomes **two-column** (`hide: navigation` front matter) for layout consistency with the agent-memory and engine homes.

## Why

Every Mercury-family member should surface the family from its home page, so a reader landing on any member discovers the whole foundation set. Same-day treatment with Accenture/mercury-composable#352, Accenture/mercury#255, and the mercury-nodejs twin.

Verified: `mkdocs build --strict` is green and the rendering was checked live — two-column home, membership line, family page under Orientation.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>